### PR TITLE
Fixed remote docker compose config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+.vscode/
+acme.json/
+data-node/
+traefik.toml/
+docker-compose.yml
+.DS_Store

--- a/docker-compose.remote.yml
+++ b/docker-compose.remote.yml
@@ -17,7 +17,7 @@ services:
       - db
     networks: 
       - backend
-      - front
+      - proxy
   frontend:
     build:
       context: ./frontend/


### PR DESCRIPTION
The remote docker-compose yml file, use the wrong name for the public network on the backend container.